### PR TITLE
Transpile to commonjs-style modules.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "esnext",
+    "module": "commonjs",
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,


### PR DESCRIPTION
This makes this node, not just Chrome, compatible. esnext/es6/etc are still not supported in node:
https://stackoverflow.com/a/37132668

Fixes #11.