### PR TITLE
Duplicate React copy in the same app

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack": "^4.16.1",
     "webpack-cli": "^3.1.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.8.6"
   }
 }


### PR DESCRIPTION
Setting `React` as a dependency will result in `Invalid hook call. Hooks can only be called inside of the body of a function component.`. This happens when calling or using `useTimer` hook. Following the documentation and after verifying every part of the issue, I found that you are depending on `react` so I had to use `peerDependencies`.

For more information:

- React docs: https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react
- Npm docs: https://nodejs.org/es/blog/npm/peer-dependencies/