### PR TITLE
Fix performance.now on React Native and SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-compound-timer
 
-Timer compound component for react to make building timers less painfull.
+Timer compound component for react and react-native to make building timers less painfull.
 It incapsulates all timer logic - you should only think about rendering!
 
 [See Working Examples](https://volkov97.github.io/react-compound-timer/)
@@ -194,4 +194,36 @@ Each object contains time and callback, that will be fired, when timer intersect
         </React.Fragment>
     )}
 </Timer>
+```
+
+## React Native
+Timer compound component also works for react-native applications. All you have to do is wrap the elements in a <Text> tag from react-native.
+
+### Countdown example with milliseconds
+```jsx
+import { View, Text } from 'react-native'
+import Timer from 'react-compound-timer'
+
+<View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Timer
+        initialTime={60 * 1000}
+        direction="backward"
+        timeToUpdate={10}
+        checkpoints={[
+            {
+                time: 0,
+                callback: () => alert('countdown finished'),
+            },
+        ]}
+    >
+        <Text style={{ fontFamily: 'Helvetica Neue' }}>
+            <Text style={{ fontSize: 32 }}>
+                <Timer.Seconds />
+            </Text>
+            <Text style={{ fontSize: 12 }}>
+                <Timer.Milliseconds />
+            </Text>
+        </Text>
+    </Timer>
+</View>
 ```

--- a/src/lib/helpers/now.test.ts
+++ b/src/lib/helpers/now.test.ts
@@ -1,0 +1,41 @@
+import now from './now';
+
+declare const global;
+
+describe('#now', () => {
+  let windowSpy;
+  let performanceSpy;
+  let dateSpy;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(global, 'window', 'get');
+    performanceSpy = jest.spyOn(window.performance, 'now');
+    dateSpy = jest.spyOn(Date, 'now');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('Calls performance.now() when performance is in window', () => {
+    now();
+
+    expect(performanceSpy).toHaveBeenCalled();
+  });
+
+  it('Calls Date.now() when window is not defined', () => {
+    windowSpy.mockImplementation(() => undefined);
+
+    now();
+
+    expect(dateSpy).toHaveBeenCalled();
+  });
+
+  it('Calls Date.now() when performance is not in window', () => {
+    windowSpy.mockImplementation(() => { });
+
+    now();
+
+    expect(dateSpy).toHaveBeenCalled();
+  });
+});

--- a/src/lib/helpers/now.ts
+++ b/src/lib/helpers/now.ts
@@ -1,0 +1,7 @@
+export default function now(): number {
+  if (typeof window === 'undefined' || !('performance' in window)) {
+    return Date.now();
+  }
+
+  return performance.now();
+}

--- a/src/lib/models/TimerModel.ts
+++ b/src/lib/models/TimerModel.ts
@@ -1,4 +1,5 @@
 import getTimeParts from '../helpers/getTimeParts';
+import now from '../helpers/now';
 
 import TimerState from './TimerState';
 import { TimeParts, Checkpoint, Direction, TimerValue, Unit } from '../../types';
@@ -30,7 +31,7 @@ export class TimerModel {
     checkpoints: Checkpoint[];
     onChange: (timerValue?: TimerValue) => void;
   }) {
-    this.internalTime = performance.now();
+    this.internalTime = now();
     this.initialTime = initialTime;
     this.time = initialTime;
     this.direction = direction;
@@ -56,7 +57,7 @@ export class TimerModel {
   }
 
   public setTime(time: number) {
-    this.internalTime = performance.now();
+    this.internalTime = now();
     this.initialTime = time;
     this.time = this.initialTime;
 
@@ -130,7 +131,7 @@ export class TimerModel {
       clearInterval(this.timerId);
     }
 
-    this.internalTime = performance.now();
+    this.internalTime = now();
 
     const repeatedFunc = () => {
       const oldTime = this.time;
@@ -158,7 +159,7 @@ export class TimerModel {
 
   private computeTime() {
     if (this.innerState.isPlaying()) {
-      const currentInternalTime = performance.now();
+      const currentInternalTime = now();
       const delta = Math.abs(currentInternalTime - this.internalTime);
 
       switch (this.direction) {


### PR DESCRIPTION
Thanks a lot for this library, it's pretty helpful! I wanted to use it in my react native application and it broke. Therefore here is a PR to fix it :)

- On react native window.performance is not available
- On servers window is not available
- This makes sure that any application using this library will not break

This is the error when using the library in a react native application
<img src="https://user-images.githubusercontent.com/1671563/74924208-5440ec80-53d2-11ea-87ee-aed00a30f98b.PNG" width="300" height="650">

Here is a video of the timer with this fix, working in react native:
![countdown](https://user-images.githubusercontent.com/1671563/74924218-57d47380-53d2-11ea-9878-dd18f93027fa.gif)
ps: the framerate of the gif is pretty low, which is why the milliseconds look slow

fixes #20 